### PR TITLE
feat: support rust-toolchain.toml file format

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -36,9 +36,14 @@ let
   pkgs = makePkgs {
     override = overrides.pkgs or (_: _: { });
     toolchainChannel =
-      let rustToolchain = root + "/rust-toolchain"; in
+      let
+        rustToolchain = root + "/rust-toolchain";
+        rustTomlToolchain = root + "/rust-toolchain.toml";
+      in
       if builtins.pathExists rustToolchain
       then rustToolchain
+      else if builtins.pathExists rustTomlToolchain
+      then rustTomlToolchain
       else workspaceMetadata.toolchain or packageMetadata.toolchain or "stable";
   };
   libb = lib // pkgs.nciUtils;


### PR DESCRIPTION
Currently, nix-cargo-integration only checks if a `rust-toolchain` file exists, but [recently](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) support for a new and better rust-toolchain, using TOML, was added.

Parsing the Toml file already works fine, since you can just rename `rust-toolchain.toml` to `rust-toolchain` and it works.