### PR TITLE
docs(manual): add tips and tricks section

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -5,6 +5,7 @@
 - [Generating a nixpkgs-compatible package expression](#generating-a-nixpkgs-compatible-package-expression)
 - [Using the `nci` CLI](#using-the-nci-cli)
 - [Enabling trace](#enabling-trace)
+- [Tips and Tricks](#tips-and-tricks)
 
 ## Library documentation
 
@@ -165,3 +166,24 @@ NCI_DEBUG=1 nix build --impure .
 [crate2nix]: https://github.com/kolloch/crate2nix "crate2nix"
 [flake-compat]: https://github.com/edolstra/flake-compat "flake-compat"
 [buildRustPackage]: https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#compiling-rust-applications-with-cargo-compiling-rust-applications-with-cargo "buildRustPackage"
+
+## Tips and tricks
+
+### Ignoring `Cargo.lock` in Rust libraries
+
+The [official recommendation](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html) for Rust libraries is to add `Cargo.lock` to the `.gitignore`.
+This conflicts with the way paths are evaluated when using a `flake.nix`. Only files
+tracked by the version control system (i.e. git) can be accessed during evaluation.
+This will manifest in the following error:
+```console
+$ nix build
+error: A Cargo.lock file must be present, please make sure it's at least staged in git.
+(use '--show-trace' to show detailed location information)
+```
+
+A neat fix for that is to track the path to `Cargo.lock` without staging it
+([thanks to @bew](https://github.com/yusdacra/nix-cargo-integration/issues/46#issuecomment-962589582)).
+```console
+$ git add --intend-to-add Cargo.lock
+```
+Add `--force` if your `Cargo.lock` is listed in `.gitignore`.


### PR DESCRIPTION
Contains the tip regarding handling `Cargo.lock` when building a library (fixes #46)

Let me know if I should rephrase anything!