### PR TITLE
feat: add aarch64-darwin to list of supported archs

### DIFF
--- a/src/lib.nix
+++ b/src/lib.nix
@@ -7,7 +7,7 @@ let
     isCrate2Nix = platform: platform == "crate2nix";
     isBuildRustPackage = platform: platform == "buildRustPackage";
     # equal to `nixpkgs` `supportedSystems` and `limitedSupportSystems` https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/release.nix#L14
-    defaultSystems = [ "aarch64-linux" "x86_64-darwin" "x86_64-linux" "i686-linux" ];
+    defaultSystems = [ "aarch64-linux" "x86_64-darwin" "x86_64-linux" "i686-linux" "aarch64-darwin" ];
     # Tries to convert a cargo license to nixpkgs license.
     cargoLicenseToNixpkgs = license:
       let


### PR DESCRIPTION
Small change to add in support for apple on aarch64-darwin. Tested by building the `nci-cli` output for aarch64-darwin. Seems to work for that example.