### PR TITLE
feat: properly combine crateOverrides for builds, remove mainBuild

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -35,15 +35,18 @@ Generates outputs for all systems specified in `Cargo.toml` (defaults to `defaul
     - `overrides.systems`: mutate the list of systems to generate for (type: `def: [ ]`)
     - `overrides.sources`: override for the sources used by common (type: `common: prev: { }`)
     - `overrides.pkgs`: override for the configuration while importing nixpkgs in common (type: `common: prev: { }`)
-    - `overrides.crateOverrides`: override for crate2nix crate overrides (type: `common: prev: { }`)
+    - `overrides.crateOverrides`: override for crate overrides (type: `common: prev: { }`)
+        - with [crate2nix], this will allow you to override per-crate
+        - with [naersk], the overrides here will be collected and be used for
+        overriding the dependencies derivation / main derivation.
+        - with [buildRustPackage], the overrides here will be collected and
+        be used for overriding the resulting derivation.
     - `overrides.common`: override for common (type: `prev: { }`)
         - this will override *all* common attribute set(s), refer to [common.nix](./common.nix) for more information
     - `overrides.shell`: override for devshell (type: `common: prev: { }`)
         - this will override *all* [devshell] configuration(s), refer to [devshell] for more information
     - `overrides.build`: override for build config (type: `common: prev: { }`)
         - this will override [naersk]/[crate2nix]/[buildRustPackage] build config, refer to [naersk]/[crate2nix]/[buildRustPackage] for more information
-    - `overrides.mainBuild`: override for main crate build derivation (type: `common: prev: { }`)
-        - this will override *all* [naersk]/[crate2nix]/[buildRustPackage] main crate build derivation(s), refer to [naersk]/[crate2nix]/[buildRustPackage] for more information
 - `renameOutputs`: which crates to rename in package names and output names (type: attrset) (default: `{ }`)
 - `defaultOutputs`: which outputs to set as default (type: attrset) (default: `{ }`)
     - `defaultOutputs.app`: app output name to set as default app (`defaultApp`) output (type: string)

--- a/src/build.nix
+++ b/src/build.nix
@@ -68,18 +68,18 @@ let
     ];
 
   # Base config for buildRustPackage platform.
-  baseBRPConfig = applyOverrides rec {
+  baseBRPConfig = common.lib.crateOverridesCombined (applyOverrides rec {
     pname = pkgName;
     inherit (cargoPkg) version;
-    inherit (common) root buildInputs nativeBuildInputs cargoVendorHash;
+    inherit (common) root cargoVendorHash;
     inherit doCheck memberPath;
     buildFlags = releaseOption ++ packageOption ++ featuresOption;
     checkFlags = releaseOption ++ packageOption ++ featuresOption;
-  };
+  });
 
   # Base config for naersk platform.
   baseNaerskConfig = {
-    inherit (common) root nativeBuildInputs buildInputs;
+    inherit (common) root;
     inherit (cargoPkg) version;
     name = pkgName;
     allRefs = true;
@@ -90,7 +90,7 @@ let
       def ++ [ "--tests" "--bins" "--examples" ]
       ++ lib.optional library "--lib"
       ++ packageOption ++ featuresOption;
-    override = _: commonConfig;
+    override = prev: common.lib.crateOverridesCombined (commonConfig // prev);
     overrideMain = applyOverrides;
     copyLibs = library;
     inherit release doCheck doDoc;

--- a/src/common.nix
+++ b/src/common.nix
@@ -95,7 +95,7 @@ let
   crateOverridesCombined =
     let
       filteredOverrides = builtins.removeAttrs noPropagatedEnvOverrides [ cargoPkg.name ];
-      func = prev: libb.pipe prev (libb.attrValues filteredOverrides);
+      func = prev: libb.pipe prev (builtins.map (ov: (prev: prev // (ov prev))) (libb.attrValues filteredOverrides));
     in
     func;
   # The main crate override is taken here

--- a/src/common.nix
+++ b/src/common.nix
@@ -94,7 +94,7 @@ let
   # Combine all crate overrides into one big override function, except the main crate override
   crateOverridesCombined =
     let
-      filteredOverrides = builtins.removeAttrs [ packageMetadata.name ] noPropagatedEnvOverrides;
+      filteredOverrides = builtins.removeAttrs noPropagatedEnvOverrides [ packageMetadata.name ];
       func = prev: libb.pipe prev (libb.attrValues filteredOverrides);
     in
     func;

--- a/src/common.nix
+++ b/src/common.nix
@@ -94,7 +94,7 @@ let
   # Combine all crate overrides into one big override function, except the main crate override
   crateOverridesCombined =
     let
-      filteredOverrides = libb.removeAttrs [ packageMetadata.name ] noPropagatedEnvOverrides;
+      filteredOverrides = builtins.removeAttrs [ packageMetadata.name ] noPropagatedEnvOverrides;
       func = prev: libb.pipe prev (libb.attrValues filteredOverrides);
     in
     func;

--- a/src/common.nix
+++ b/src/common.nix
@@ -94,12 +94,12 @@ let
   # Combine all crate overrides into one big override function, except the main crate override
   crateOverridesCombined =
     let
-      filteredOverrides = builtins.removeAttrs noPropagatedEnvOverrides [ packageMetadata.name ];
+      filteredOverrides = builtins.removeAttrs noPropagatedEnvOverrides [ cargoPkg.name ];
       func = prev: libb.pipe prev (libb.attrValues filteredOverrides);
     in
     func;
   # The main crate override is taken here
-  mainBuildOverride = noPropagatedEnvOverrides.${packageMetadata.name} or (_: { });
+  mainBuildOverride = noPropagatedEnvOverrides.${cargoPkg.name} or (_: { });
 
   # TODO: try to convert cargo maintainers to nixpkgs maintainers
   meta = {

--- a/src/common.nix
+++ b/src/common.nix
@@ -90,6 +90,8 @@ let
   crateOverridesEmpty = libb.mapAttrsToList (_: v: v { }) crateOverrides;
   # Get a field from all overrides in "empty" crate overrides and flatten them. Mainly used to collect (native) build inputs.
   crateOverridesGetFlattenLists = attrName: libb.unique (libb.flatten (builtins.map (v: v.${attrName} or [ ]) crateOverridesEmpty));
+  # Combine all crate overrides into one big override function
+  crateOverridesCombined = prev: libb.pipe prev (libb.attrValues (libb.removePropagatedEnv crateOverrides));
 
   # TODO: try to convert cargo maintainers to nixpkgs maintainers
   meta = {
@@ -107,6 +109,7 @@ let
       inherit
         crateOverridesGetFlattenLists
         crateOverridesEmpty
+        crateOverridesCombined
         makePkgs;
     } // libb;
 

--- a/src/common.nix
+++ b/src/common.nix
@@ -99,7 +99,7 @@ let
     in
     func;
   # The main crate override is taken here
-  mainBuildOverride = noPropagatedEnvOverrides.${cargoPkg.name} or (_: { });
+  mainBuildOverride = prev: prev // ((noPropagatedEnvOverrides.${cargoPkg.name} or (_: {})) prev);
 
   # TODO: try to convert cargo maintainers to nixpkgs maintainers
   meta = {


### PR DESCRIPTION
`overrides.mainBuild` is removed in favour of `overrides.crateOverrides.your-crate-name`. This should fix #50.