### PR TITLE
fix: Replace pkgs.libudev with pkgs.udev

### DIFF
--- a/src/extra-crate-overrides.nix
+++ b/src/extra-crate-overrides.nix
@@ -22,7 +22,7 @@
 in {
   inherit ffmpeg-sys-next;
   ffmpeg-sys = ffmpeg-sys-next;
-  libudev-sys = with pkgs; mkOv [libudev] [pkg-config];
+  libudev-sys = with pkgs; mkOv [udev] [pkg-config];
   alsa-sys = with pkgs; mkOv [alsa-lib] [pkg-config];
   xcb = with pkgs; mkOv [xorg.libxcb] [python3];
   xkbcommon-sys = with pkgs; mkOv [libxkbcommon] [pkg-config];


### PR DESCRIPTION
I've been encountering an error with recent revisions of nixpkgs and nci, where building anything/entering the devshell would get me:

```
error: 'libudev' has been renamed to/replaced by 'udev'
```

The culprit must be `a36f455` in nixpkgs:

```
614⋮    │  libudev = udev; # Added 2018-04-25
   ⋮ 613│  libudev = throw "'libudev' has been renamed to/replaced by 'udev'"; # Converted to throw 2022-02-22
```

Because `src/extra-crate-overrides.nix:25` defines:

```
libudev-sys = with pkgs; mkOv [udev] [pkg-config];
```

This PR simply uses the `udev` package directly rather than the alias. This will break repos still using a nearly 3 years old nixpkgs.
