### PR TITLE
fix: replace defaultApp with apps.${system}.default

### DIFF
--- a/src/makeOutput.nix
+++ b/src/makeOutput.nix
@@ -119,9 +119,8 @@ in
       };
     }
     // l.optionalAttrs (packageMetadata.app or false) {
-      inherit apps;
-      defaultApp = {
-        ${system} = let
+      apps = l.recursiveUpdate apps {
+        ${system}.default = let
           appName =
             if (l.length allBins) > 0
             then (l.head allBins).name


### PR DESCRIPTION
A possible fix for issue #81. It replaces `defaultApp` with `apps.${system}.default`. 

Not sure if this is the correct way to do this, but it seems to work for my little toy app.