### PR TITLE
fix(deps): update input follows

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,5 @@
 {
   "nodes": {
-    "all-cabal-json": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1665552503,
-        "narHash": "sha256-r14RmRSwzv5c+bWKUDaze6pXM7nOsiz1H8nvFHJvufc=",
-        "owner": "nix-community",
-        "repo": "all-cabal-json",
-        "rev": "d7c0434eebffb305071404edcf9d5cd99703878e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "hackage",
-        "repo": "all-cabal-json",
-        "type": "github"
-      }
-    },
     "crane": {
       "flake": false,
       "locked": {
@@ -51,33 +34,21 @@
     },
     "dream2nix": {
       "inputs": {
-        "alejandra": [
-          "nixpkgs"
-        ],
-        "all-cabal-json": "all-cabal-json",
+        "alejandra": [],
+        "all-cabal-json": [],
         "crane": "crane",
         "devshell": [
           "devshell"
         ],
-        "flake-utils-pre-commit": [
-          "nixpkgs"
-        ],
-        "ghc-utils": "ghc-utils",
-        "gomod2nix": [
-          "nixpkgs"
-        ],
-        "mach-nix": [
-          "nixpkgs"
-        ],
+        "flake-utils-pre-commit": [],
+        "ghc-utils": [],
+        "gomod2nix": [],
+        "mach-nix": [],
         "nixpkgs": [
           "nixpkgs"
         ],
-        "poetry2nix": [
-          "nixpkgs"
-        ],
-        "pre-commit-hooks": [
-          "nixpkgs"
-        ]
+        "poetry2nix": [],
+        "pre-commit-hooks": []
       },
       "locked": {
         "lastModified": 1668740392,
@@ -91,22 +62,6 @@
         "owner": "nix-community",
         "repo": "dream2nix",
         "type": "github"
-      }
-    },
-    "ghc-utils": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1662774800,
-        "narHash": "sha256-1Rd2eohGUw/s1tfvkepeYpg8kCEXiIot0RijapUjAkE=",
-        "ref": "refs/heads/master",
-        "rev": "bb3a2d3dc52ff0253fb9c2812bd7aa2da03e0fea",
-        "revCount": 1072,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/bgamari/ghc-utils"
-      },
-      "original": {
-        "type": "git",
-        "url": "https://gitlab.haskell.org/bgamari/ghc-utils"
       }
     },
     "nixpkgs": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,14 +13,19 @@
 
     dream2nix = {
       url = "github:nix-community/dream2nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.gomod2nix.follows = "nixpkgs";
-      inputs.mach-nix.follows = "nixpkgs";
-      inputs.poetry2nix.follows = "nixpkgs";
-      inputs.alejandra.follows = "nixpkgs";
-      inputs.pre-commit-hooks.follows = "nixpkgs";
-      inputs.flake-utils-pre-commit.follows = "nixpkgs";
-      inputs.devshell.follows = "devshell";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        devshell.follows = "devshell";
+
+        alejandra.follows = "";
+        all-cabal-json.follows = "";
+        flake-utils-pre-commit.follows = "";
+        ghc-utils.follows = "";
+        gomod2nix.follows = "";
+        mach-nix.follows = "";
+        poetry2nix.follows = "";
+        pre-commit-hooks.follows = "";
+      };
     };
   };
 


### PR DESCRIPTION
In 5bdbaf39, the `dream2nix` input got updated to a version that includes [all-cabal-json](https://github.com/nix-community/all-cabal-json) as an input. The tarball for that input is ~192 MB, and when extracted, it produces so many files that it takes some of my less powerful systems upwards of 20 minutes just to chech the NAR hash.

As far as I can tell, we don't actually make use of any `dream2nix` functions that use this input. I also noticed that other unused inputs had been overriden to point to nixpkgs, which I assume was done to avoid downloading them too.

This pull request updates the `follows` values for the unused inputs so that they're all set to `""`, meaning nothing will be downloaded for them.

It might also be a good idea to modify the [flake update workflow](https://github.com/yusdacra/nix-cargo-integration/blob/master/.github/workflows/flake-update.yml) so that it checks whether any new inputs have been added, to avoid this sort of thing happening again in the future.