### PR TITLE
Allow overriding stdenv

### DIFF
--- a/src/implementation.nix
+++ b/src/implementation.nix
@@ -89,6 +89,11 @@ in {
               cargo = nci.toolchains.build;
               rustc = nci.toolchains.build;
             };
+          }
+          // l.optionalAttrs (nci.stdenv != null) {
+            "^.*".set-stdenv.override = _: {
+              stdenv = nci.stdenv;
+            };
           };
       };
 

--- a/src/interface.nix
+++ b/src/interface.nix
@@ -40,6 +40,12 @@ in {
             '';
             description = "Profiles to generate packages for all crates";
           };
+          nci.stdenv = l.mkOption {
+            type = t.nullOr t.package;
+            description = "The stdenv that will be used.";
+            default = null;
+            example = l.literalExpression "pkgs.clangStdenv";
+          };
           nci.toolchains = {
             build = l.mkOption {
               type = t.package;


### PR DESCRIPTION
Currently, there is no other way to override `stdenv` (e.g. to use clang instead of gcc). This PR adds this functionality.