### PR TITLE
implementation: fix profiles null detection

### DIFF
--- a/src/implementation.nix
+++ b/src/implementation.nix
@@ -134,7 +134,7 @@ in {
               runtimeLibs =
                 (project.runtimeLibs or [])
                 ++ (nci.crates.${name}.runtimeLibs or []);
-              crateProfiles = nci.crates.${name}.profiles;
+              crateProfiles = nci.crates.${name}.profiles or null;
             in
               if package ? override
               then {


### PR DESCRIPTION
Without this patch setting `export = true;` will fail on the fixed line (unless I specify all my crates in `crates`).