### PR TITLE
Change features behaviour to make it possible to disable defaults

### DIFF
--- a/src/functions/mkPackagesFromRaw.nix
+++ b/src/functions/mkPackagesFromRaw.nix
@@ -7,13 +7,19 @@
   l = pkgs.lib // builtins;
   makePackage = profile: conf: let
     flags =
-      if l.length conf.features > 0
-      then [
-        "--no-default-features"
-        "--features"
-        "${l.concatStringsSep "," conf.features}"
-      ]
-      else [];
+      (
+        if conf.noDefaultFeatures
+        then ["--no-default-features"]
+        else []
+      )
+      ++ (
+        if l.length conf.features > 0
+        then [
+          "--features"
+          "${l.concatStringsSep "," conf.features}"
+        ]
+        else []
+      );
     common = {
       cargoTestProfile = profile;
       cargoBuildProfile = profile;

--- a/src/functions/mkPackagesFromRaw.nix
+++ b/src/functions/mkPackagesFromRaw.nix
@@ -7,19 +7,12 @@
   l = pkgs.lib // builtins;
   makePackage = profile: conf: let
     flags =
-      (
-        if conf.noDefaultFeatures
-        then ["--no-default-features"]
-        else []
-      )
-      ++ (
-        if l.length conf.features > 0
-        then [
-          "--features"
-          "${l.concatStringsSep "," conf.features}"
-        ]
-        else []
-      );
+      if l.length conf.features > 0
+      then [
+        "--features"
+        "${l.concatStringsSep "," conf.features}"
+      ]
+      else ["--no-default-features"];
     common = {
       cargoTestProfile = profile;
       cargoBuildProfile = profile;

--- a/src/modules/profile.nix
+++ b/src/modules/profile.nix
@@ -11,6 +11,12 @@ in {
       '';
       description = "Features to enable for this profile";
     };
+    noDefaultFeatures = l.mkOption {
+      type = t.bool;
+      default = false;
+      example = true;
+      description = "Whether to disable default features for this profile";
+    };
     runTests = l.mkOption {
       type = t.bool;
       default = false;

--- a/src/modules/profile.nix
+++ b/src/modules/profile.nix
@@ -5,17 +5,11 @@ in {
   options = {
     features = l.mkOption {
       type = t.listOf t.str;
-      default = [];
+      default = ["default"];
       example = l.literalExpression ''
         ["tracing" "publish"]
       '';
       description = "Features to enable for this profile";
-    };
-    noDefaultFeatures = l.mkOption {
-      type = t.bool;
-      default = false;
-      example = true;
-      description = "Whether to disable default features for this profile";
     };
     runTests = l.mkOption {
       type = t.bool;


### PR DESCRIPTION
This allows the `--no-default-features` flag to be set independently of the `--features` option.