### PR TITLE
Fix workspace glob pattern support

### DIFF
--- a/src/functions/getProjectCrates.nix
+++ b/src/functions/getProjectCrates.nix
@@ -19,7 +19,7 @@
           if l.last components == "*"
           then let
             parentDirRel = l.concatStringsSep "/" (l.init components);
-            dirs = l.readDir projectRoot;
+            dirs = l.readDir "${projectRoot}/${parentDirRel}";
           in
             l.mapAttrsToList
             (name: _: "${parentDirRel}/${name}")


### PR DESCRIPTION
Fixing an issue with glob patterns in cargo workspace members not being resolved correctly.

# Issue

When using a `Cargo.toml` with a crates folder and glob pattern:

```
[workspace]
members = [
  "crates/*",
  "xtask",
]
```

Then the `readDir` to lookup all the crates was executed on the project root folder, but not the actual `crates` sub-folder. This way the actual crates are not found and the `crates` folder itself is treated as a crate. Building a flake with this configuration will fail.