### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ and then inside the `mkFlake`:
 ### Ignoring `Cargo.lock` in Rust libraries
 
 The [official recommendation](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html)
-for Rust libraries is to add `Cargo.lock` to the `.gitignore`. This conflicts
+for Rust libraries *used to* say to add `Cargo.lock` to the `.gitignore`.
+[This is now no longer the case](https://blog.rust-lang.org/2023/08/29/committing-lockfiles.html),
+however older projects may still do this, which will cause conflicts
 with the way paths are evaluated when using a `flake.nix`. Only files tracked
 by the version control system (i.e. git) can be accessed during evaluation.
 This will manifest in the following warning:


### PR DESCRIPTION
rewrite add Cargo.lock to git to acknowledge that it is not officially recommended to add Cargo.lock to .gitignore anymore.