### PR TITLE
docs: add missing `literalExpression`

### DIFF
--- a/src/modules/project.nix
+++ b/src/modules/project.nix
@@ -21,7 +21,7 @@ in {
   options = {
     path = l.mkOption {
       type = t.path;
-      example = "./path/to/project";
+      example = lib.literalExpression "./path/to/project";
       description = "The absolute path of this project";
     };
 


### PR DESCRIPTION
`path` is a *path*, not a string.
