### PR TITLE
chore: update rust edition in examples/templates

### DIFF
--- a/examples/cross-compile-aarch64/Cargo.toml
+++ b/examples/cross-compile-aarch64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cross-compile-aarch64"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 openssl-sys = "*"

--- a/examples/cross-compile-wasm/Cargo.toml
+++ b/examples/cross-compile-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cross-compile"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 yew = { version="0.21", features=["csr"] }

--- a/examples/cross-compile-windows/Cargo.toml
+++ b/examples/cross-compile-windows/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cross-compile-windows"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 openssl-sys = "*"

--- a/examples/customize-profiles/Cargo.toml
+++ b/examples/customize-profiles/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "customize-profiles"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [features]
 default = []

--- a/examples/customize-stdenv/Cargo.toml
+++ b/examples/customize-stdenv/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "my-crate"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"

--- a/examples/numtide-devshell/Cargo.toml
+++ b/examples/numtide-devshell/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "my-crate"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"

--- a/examples/simple-crate/Cargo.toml
+++ b/examples/simple-crate/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "my-crate"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"

--- a/examples/simple-workspace/Cargo.toml
+++ b/examples/simple-workspace/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["my-workspace-crate", "./my-other-workspace-crate"]
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Some Author <someone@example.com>", "Another Author <someone.else@example.com>"]
 license = "MIT"
 repository = "https://github.com/90-008/nix-cargo-integration/tree/master/examples/simple-workspace"


### PR DESCRIPTION
Hi, I'm not sure this is as easy as I imagine it, so don't hesitate to reject this PR.

I noticed that the examples/templates use quite old rust versions, at least some of them. I updated all rust editions to `2024` in all examples.